### PR TITLE
replace deprecated usage of go get with go install

### DIFF
--- a/.github/workflows/auto_import.yaml
+++ b/.github/workflows/auto_import.yaml
@@ -20,7 +20,7 @@ jobs:
         wget https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.zip
         unzip nvdcve-1.1-modified.json.zip
     - run: |
-        go get -u github.com/google/osv/vulnfeeds/cmd/pypi
+        go install github.com/google/osv/vulnfeeds/cmd/pypi@latest
         pypi -false_positives triage/false_positives.yaml \
             -nvd_json nvdcve-1.1-modified.json \
             -pypi_links pypi_links.json \

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -37,7 +37,7 @@ jobs:
       with:
         go-version: '^1.16.4'
     - run: |
-        go get -u github.com/google/osv/vulnfeeds/cmd/ids
+        go install github.com/google/osv/vulnfeeds/cmd/ids@latest
         ids -dir=./vulns -prefix PYSEC
         git config user.name github-actions
         git config user.email github-actions@github.com


### PR DESCRIPTION
The [auto import job is currently failing](https://github.com/pypa/advisory-database/runs/6478070272?check_suite_focus=true#step:6:22) because `go get` has been deprecated. 

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>