### PR TITLE
Make PYSEC-2019-169's range encoding more concise.

### DIFF
--- a/vulns/pyspark/PYSEC-2019-169.yaml
+++ b/vulns/pyspark/PYSEC-2019-169.yaml
@@ -10,12 +10,9 @@ affected:
   ranges:
   - type: ECOSYSTEM
     events:
-    - introduced: 2.1.0
     - introduced: 2.3.0
     - fixed: 2.3.2
     - introduced: 1.0.2
-    - introduced: 2.0.0
-    - introduced: 2.2.0
     - fixed: 2.2.3
   versions:
   - 2.1.1


### PR DESCRIPTION
For #80. There are no functional differences here. 