### PR TITLE
Replace outdated URL shortener link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is community owned repository of advisories for packages published on
 https://pypi.org.
 
 Advisories live in the [vulns](vulns/) directory and use a YAML encoding of
-a [simple format](https://tinyurl.com/vuln-json).
+a [simple format](https://ossf.github.io/osv-schema/).
 
 ## Contributing advisories
 


### PR DESCRIPTION
<https://tinyurl.com/vuln-json> redirects to <https://docs.google.com/document/d/1sylBGNooKtf220RHQn1I8pZRmqXZQADDQ_TOABrKTpA/edit> which tells you to refer to <https://ossf.github.io/osv-schema/>. This change saves the user a click, and removes the middleman.