### PR TITLE
python-jwt vulnerability: forge token with new claims

### DIFF
--- a/vulns/python-jwt/PYSEC-0000-forge.yaml
+++ b/vulns/python-jwt/PYSEC-0000-forge.yaml
@@ -39,6 +39,6 @@ references:
   url: https://github.com/davedoesdev/python-jwt/commit/88ad9e67c53aa5f7c43ec4aa52ed34b7930068c9
 credits:
 - name: Tom Tervoort
-  contact: tom.tervoort@secura.com
+  contact: "mailto:tom.tervoort@secura.com"
 modified: "2022-09-01T18:51:51Z"
 published: "2022-09-01T18:51:51Z"

--- a/vulns/python-jwt/PYSEC-0000-forge.yaml
+++ b/vulns/python-jwt/PYSEC-0000-forge.yaml
@@ -1,0 +1,41 @@
+id: PYSEC-0000-forge
+details: An attacker who obtains a JWT can arbitrarily forge its contents without knowing
+  the secret key. Depending on the application, this may for example enable the attacker to
+  spoof other user's identities, hijack their sessions, or bypass authentication.
+affected:
+- package:
+    name: python-jwt
+    ecosystem: PyPI
+    purl: pkg:pypi/python-jwt
+  ranges:
+  - type: GIT
+    repo: https://github.com/davedoesdev/python-jwt
+    events:
+    - introduced: f6d1451012c6a04c2fb1940f0bbd93bb6cf2b025
+    - fixed: 88ad9e67c53aa5f7c43ec4aa52ed34b7930068c9
+  - type: ECOSYSTEM
+    events:
+    - introduced: 3.0.0
+    - fixed: 3.3.4
+  versions:
+  - 3.3.0
+  - 3.1.0
+  - 3.2.0
+  - 3.2.1
+  - 3.2.2
+  - 3.2.3
+  - 3.2.4
+  - 3.2.5
+  - 3.2.6
+  - 3.3.0
+  - 3.3.1
+  - 3.3.2
+  - 3.3.3
+references:
+- type: FIX
+  url: https://github.com/davedoesdev/python-jwt/commit/88ad9e67c53aa5f7c43ec4aa52ed34b7930068c9
+credits:
+- name: Tom Tervoort
+  contact: tom.tervoort@secura.com
+modified: "2022-09-01T18:51:51Z"
+published: "2022-09-01T18:51:51Z"

--- a/vulns/python-jwt/PYSEC-0000-forge.yaml
+++ b/vulns/python-jwt/PYSEC-0000-forge.yaml
@@ -2,6 +2,9 @@ id: PYSEC-0000-forge
 details: An attacker who obtains a JWT can arbitrarily forge its contents without knowing
   the secret key. Depending on the application, this may for example enable the attacker to
   spoof other user's identities, hijack their sessions, or bypass authentication.
+severity:
+- type: CVSS_V3
+  score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
 affected:
 - package:
     name: python-jwt


### PR DESCRIPTION
It allows an attacker, who possesses a single valid JWT,
to create a new token with forged claims that the verify_jwt
function will accept as valid.

The issue is caused by an inconsistency between the JWT parsers
used by python-jwt and its dependency jwcrypto. By mixing compact
and JSON representations, an attacker can trick jwcrypto of parsing
different claims than those over which a signature is validated by jwcrypto.

Found by Tom Tervoort <Tom.Tervoort@secura.com>

CVE + report will be added when he creates it.