### PR TITLE
Fix issue with parsing details in PYSEC-2022-42969

### DIFF
--- a/vulns/py/PYSEC-2022-42969.yaml
+++ b/vulns/py/PYSEC-2022-42969.yaml
@@ -1,5 +1,8 @@
 id: PYSEC-2022-42969
-details: Taken from [Github Advisory Database](https://github.com/advisories/GHSA-w596-4wvx-j9j6): The py library through 1.11.0 for Python allows remote attackers to conduct a ReDoS (Regular expression Denial of Service) attack via a Subversion repository with crafted info data, because the InfoSvnCommand argument is mishandled.
+details: The py library through 1.11.0 for Python allows remote attackers to
+  conduct a ReDoS (Regular expression Denial of Service) attack via a
+  Subversion repository with crafted info data, because the InfoSvnCommand
+  argument is mishandled.
 affected:
 - package:
     name: py


### PR DESCRIPTION
Fixes #106

**Proposed Changes**

- Remove offending link/colon from `details` for `PYSEC-2022-42969`.
 
Since it is using the official description from https://nvd.nist.gov/vuln/detail/CVE-2022-42969 and Github is linked as a reference already I removed the `Taken from ...` from `details` as it contains the offending colon.