### PR TITLE
Add vulnerability report for Adyen HMAC issue

### DIFF
--- a/vulns/adyen/PYSEC-0000-000.yaml
+++ b/vulns/adyen/PYSEC-0000-000.yaml
@@ -1,0 +1,30 @@
+id: PYSEC-0000-000
+details: Adyen has utility methods for validating notification HMAC signatures.
+  The is_valid_hmac and is_valid_hmac_notification methods are vulnerable to a 
+  timing attack, you should compare the hash of the HMACs instead.
+affected:
+- package:
+    name: adyen
+    ecosystem: PyPI
+    purl: pkg:pypi/adyen
+  ranges:
+  - type: ECOSYSTEM
+    events:
+    - introduced: 2.2.0
+    - fixed: 7.1.0
+  versions:
+  - "2.2.0"
+  - "2.3.0"
+  - "3.0.0"
+  - "3.1.0"
+  - "4.0.0"
+  - "5.0.0"
+  - "5.1.0"
+  - "6.0.0"
+  - "7.0.0"
+references:
+- type: REPORT
+  url: https://github.com/Adyen/adyen-python-api-library/issues/168
+- type: FIX
+  url: https://github.com/Adyen/adyen-python-api-library/pull/170
+

--- a/vulns/adyen/PYSEC-0000-000.yaml
+++ b/vulns/adyen/PYSEC-0000-000.yaml
@@ -27,4 +27,5 @@ references:
   url: https://github.com/Adyen/adyen-python-api-library/issues/168
 - type: FIX
   url: https://github.com/Adyen/adyen-python-api-library/pull/170
-
+modified: '2023-01-24T00:00:00Z'
+published: '2023-01-24T00:00:00Z'


### PR DESCRIPTION
This vulnerability only came to our attention because it was listed in safetydb (identifier `pyup.io-51293`).