### PR TITLE
Update PYSEC-2023-46.yaml

### DIFF
--- a/vulns/redis/PYSEC-2023-46.yaml
+++ b/vulns/redis/PYSEC-2023-46.yaml
@@ -12,6 +12,8 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
+    - fixed: 4.4.4
+    - introduced: 4.5.0
     - fixed: 4.5.4
   versions:
   - 0.6.0

--- a/vulns/redis/PYSEC-2023-46.yaml
+++ b/vulns/redis/PYSEC-2023-46.yaml
@@ -12,7 +12,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - fixed: 5.0.0b1
+    - fixed: 4.5.4
   versions:
   - 0.6.0
   - 0.6.1
@@ -115,12 +115,10 @@ affected:
   - 4.4.1
   - 4.4.2
   - 4.4.3
-  - 4.4.4
   - 4.5.0
   - 4.5.1
   - 4.5.2
   - 4.5.3
-  - 4.5.4
 references:
 - type: WEB
   url: https://github.com/redis/redis-py/pull/2641
@@ -128,5 +126,5 @@ references:
   url: https://github.com/redis/redis-py/issues/2665
 aliases:
 - CVE-2023-28859
-modified: "2023-05-04T03:49:47.987510Z"
+modified: "2023-05-04T18:47:00Z"
 published: "2023-03-26T19:15:00Z"


### PR DESCRIPTION
Fix affected versions to match [CVE-2023-28859](https://github.com/advisories/GHSA-8fww-64cx-x8p5)

closes #116 