### PR TITLE
Test assigning IDs on PRs

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -6,6 +6,7 @@ on:
   schedule:
   - cron: '*/15 * * * *'
   workflow_dispatch:
+  pull_request:
 jobs:
   analysis:
     continue-on-error: false
@@ -26,6 +27,8 @@ jobs:
         git add .
     - run: git diff --cached --quiet || git commit -m 'Analysis'
     - run: git push
+      # Don't push analysis on pull requests.
+      if: ${{ github.event_name != 'pull_request' }}
   assign:
     needs: analysis
     continue-on-error: false
@@ -46,3 +49,5 @@ jobs:
         GONOPROXY: github.com/google/osv
     - run: git diff --cached --quiet || git commit -m 'Assign IDs'
     - run: git push
+      # Don't push IDs on pull requests.
+      if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
In an effort to prevent manually triaged vulns from breaking the automation figured the best way was to run the automation and throw away the results to verify that nothing is broken. If there's a better way to do this let me know, only did it this way because it was simple.