### PR TITLE
Fix affected versions in PYSEC-2023-102.yaml

### DIFF
--- a/vulns/scipy/PYSEC-2023-102.yaml
+++ b/vulns/scipy/PYSEC-2023-102.yaml
@@ -14,7 +14,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - fixed: 1.11.1
+    - fixed: 1.10.0
   versions:
   - 0.10.0
   - 0.10.1


### PR DESCRIPTION
The current version states that the bug was fixed in 1.11.1, but it seems the patch was applied already in 1.10.0

* https://github.com/advisories/GHSA-9jx5-6pgf-crrp
* https://docs.scipy.org/doc/scipy/release/1.10.0-notes.html