### PR TITLE
Update PYSEC-2023-110 to include fix information

### DIFF
--- a/vulns/langchain/PYSEC-2023-110.yaml
+++ b/vulns/langchain/PYSEC-2023-110.yaml
@@ -7,9 +7,9 @@ modified: '2023-08-28T16:50:24.862628Z'
 published: '2023-07-06T14:15:00Z'
 references:
 - type: FIX
-  url: https://github.com/hwchase17/langchain/pull/6051
+  url: https://github.com/langchain-ai/langchain/pull/8425
 - type: EVIDENCE
-  url: https://github.com/hwchase17/langchain/issues/5923
+  url: https://github.com/langchain-ai/langchain/issues/5923
 affected:
 - package:
     name: langchain
@@ -19,6 +19,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: '0.0.247'
   versions:
   - 0.0.1
   - 0.0.10
@@ -270,32 +271,3 @@ affected:
   - 0.0.244
   - 0.0.245
   - 0.0.246
-  - 0.0.247
-  - 0.0.248
-  - 0.0.249
-  - 0.0.250
-  - 0.0.251
-  - 0.0.252
-  - 0.0.253
-  - 0.0.254
-  - 0.0.255
-  - 0.0.256
-  - 0.0.257
-  - 0.0.258
-  - 0.0.259
-  - 0.0.260
-  - 0.0.261
-  - 0.0.262
-  - 0.0.263
-  - 0.0.264
-  - 0.0.265
-  - 0.0.266
-  - 0.0.267
-  - 0.0.268
-  - 0.0.269
-  - 0.0.270
-  - 0.0.271
-  - 0.0.272
-  - 0.0.273
-  - 0.0.274
-  - 0.0.275


### PR DESCRIPTION
The fix for this issue was published in langchain v0.0.247 so that one and all subsequent versions are safe.

I've also updated the URLs to point to the merged PR containing the fix, and to account for the fact that the project repo moved from a personal to an organization GitHub account.

The full details on the vulnerability and remediation can be found here: https://github.com/langchain-ai/langchain/issues/5923#issuecomment-1696053841