### PR TITLE
Update PYSEC-2023-91 to include fix information

### DIFF
--- a/vulns/langchain/PYSEC-2023-91.yaml
+++ b/vulns/langchain/PYSEC-2023-91.yaml
@@ -6,9 +6,11 @@ modified: '2023-08-28T16:50:25.676144Z'
 published: '2023-06-14T15:15:00Z'
 references:
 - type: EVIDENCE
-  url: https://github.com/hwchase17/langchain/issues/4833
+  url: https://github.com/langchain-ai/langchain/issues/4833
 - type: REPORT
-  url: https://github.com/hwchase17/langchain/issues/4833
+  url: https://github.com/langchain-ai/langchain/issues/4833
+- type: FIX
+  url: https://github.com/langchain-ai/langchain/pull/6992
 affected:
 - package:
     name: langchain
@@ -18,6 +20,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: '0.0.225'
   versions:
   - 0.0.1
   - 0.0.10
@@ -245,56 +248,3 @@ affected:
   - 0.0.222
   - 0.0.223
   - 0.0.224
-  - 0.0.225
-  - 0.0.226
-  - 0.0.227
-  - 0.0.228
-  - 0.0.229
-  - 0.0.230
-  - 0.0.231
-  - 0.0.232
-  - 0.0.233
-  - 0.0.234
-  - 0.0.235
-  - 0.0.236
-  - 0.0.237
-  - 0.0.238
-  - 0.0.239
-  - 0.0.240rc0
-  - 0.0.240rc1
-  - 0.0.240rc4
-  - 0.0.240
-  - 0.0.242
-  - 0.0.243
-  - 0.0.244
-  - 0.0.245
-  - 0.0.246
-  - 0.0.247
-  - 0.0.248
-  - 0.0.249
-  - 0.0.250
-  - 0.0.251
-  - 0.0.252
-  - 0.0.253
-  - 0.0.254
-  - 0.0.255
-  - 0.0.256
-  - 0.0.257
-  - 0.0.258
-  - 0.0.259
-  - 0.0.260
-  - 0.0.261
-  - 0.0.262
-  - 0.0.263
-  - 0.0.264
-  - 0.0.265
-  - 0.0.266
-  - 0.0.267
-  - 0.0.268
-  - 0.0.269
-  - 0.0.270
-  - 0.0.271
-  - 0.0.272
-  - 0.0.273
-  - 0.0.274
-  - 0.0.275


### PR DESCRIPTION
That advisory corresponds to:
- this issue, which is closed as completed: https://github.com/langchain-ai/langchain/issues/4833
- this PR, which is merged: https://github.com/langchain-ai/langchain/pull/6992
- this fix release, which references the above PR in the release notes: https://github.com/langchain-ai/langchain/releases/tag/v0.0.225

I'm also updating the URLs to account for the repository being moved from a personal to an organizational GitHub account.

Thanks for maintaining this database!