### PR TITLE
Add fix information for PYSEC-2023-98 and PYSEC-2023-109

### DIFF
--- a/vulns/langchain/PYSEC-2023-109.yaml
+++ b/vulns/langchain/PYSEC-2023-109.yaml
@@ -3,13 +3,13 @@ details: An issue in langchain v.0.0.64 allows a remote attacker to execute arbi
   code via the PALChain parameter in the Python exec method.
 aliases:
 - CVE-2023-36188
-modified: '2023-08-29T15:11:36.482230Z'
+modified: '2023-08-29T16:42:00.000000Z'
 published: '2023-07-06T14:15:00Z'
 references:
 - type: EVIDENCE
-  url: https://github.com/hwchase17/langchain/issues/5872
+  url: https://github.com/langchain-ai/langchain/issues/5872
 - type: FIX
-  url: https://github.com/hwchase17/langchain/pull/6003
+  url: https://github.com/langchain-ai/langchain/pull/8425
 affected:
 - package:
     name: langchain
@@ -19,6 +19,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: '0.0.247'
   versions:
   - 0.0.1
   - 0.0.10
@@ -270,33 +271,3 @@ affected:
   - 0.0.244
   - 0.0.245
   - 0.0.246
-  - 0.0.247
-  - 0.0.248
-  - 0.0.249
-  - 0.0.250
-  - 0.0.251
-  - 0.0.252
-  - 0.0.253
-  - 0.0.254
-  - 0.0.255
-  - 0.0.256
-  - 0.0.257
-  - 0.0.258
-  - 0.0.259
-  - 0.0.260
-  - 0.0.261
-  - 0.0.262
-  - 0.0.263
-  - 0.0.264
-  - 0.0.265
-  - 0.0.266
-  - 0.0.267
-  - 0.0.268
-  - 0.0.269
-  - 0.0.270
-  - 0.0.271
-  - 0.0.272
-  - 0.0.273
-  - 0.0.274
-  - 0.0.275
-  - 0.0.276

--- a/vulns/langchain/PYSEC-2023-98.yaml
+++ b/vulns/langchain/PYSEC-2023-98.yaml
@@ -3,13 +3,13 @@ details: An issue in langchain v.0.0.199 allows an attacker to execute arbitrary
   via the PALChain in the python exec method.
 aliases:
 - CVE-2023-36258
-modified: '2023-08-29T15:11:37.356071Z'
+modified: '2023-08-29T14:40:00.000000Z'
 published: '2023-07-03T21:15:00Z'
 references:
 - type: EVIDENCE
-  url: https://github.com/hwchase17/langchain/issues/5872
+  url: https://github.com/langchain-ai/langchain/issues/5872
 - type: REPORT
-  url: https://github.com/hwchase17/langchain/issues/5872
+  url: https://github.com/langchain-ai/langchain/issues/5872
 affected:
 - package:
     name: langchain
@@ -19,6 +19,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: '0.0.247'
   versions:
   - 0.0.1
   - 0.0.10
@@ -270,33 +271,3 @@ affected:
   - 0.0.244
   - 0.0.245
   - 0.0.246
-  - 0.0.247
-  - 0.0.248
-  - 0.0.249
-  - 0.0.250
-  - 0.0.251
-  - 0.0.252
-  - 0.0.253
-  - 0.0.254
-  - 0.0.255
-  - 0.0.256
-  - 0.0.257
-  - 0.0.258
-  - 0.0.259
-  - 0.0.260
-  - 0.0.261
-  - 0.0.262
-  - 0.0.263
-  - 0.0.264
-  - 0.0.265
-  - 0.0.266
-  - 0.0.267
-  - 0.0.268
-  - 0.0.269
-  - 0.0.270
-  - 0.0.271
-  - 0.0.272
-  - 0.0.273
-  - 0.0.274
-  - 0.0.275
-  - 0.0.276

--- a/vulns/langchain/PYSEC-2023-98.yaml
+++ b/vulns/langchain/PYSEC-2023-98.yaml
@@ -3,7 +3,7 @@ details: An issue in langchain v.0.0.199 allows an attacker to execute arbitrary
   via the PALChain in the python exec method.
 aliases:
 - CVE-2023-36258
-modified: '2023-08-29T14:40:00.000000Z'
+modified: '2023-08-29T16:40:00.000000Z'
 published: '2023-07-03T21:15:00Z'
 references:
 - type: EVIDENCE


### PR DESCRIPTION
The code in question was removed entirely as of `langchain v0.0.247`.

More information in this comment, which is part of the same issue where the advisory entries point: https://github.com/langchain-ai/langchain/issues/5872#issuecomment-1697785619