### PR TITLE
Update PYSEC-2023-145 with fix information

### DIFF
--- a/vulns/langchain/PYSEC-2023-145.yaml
+++ b/vulns/langchain/PYSEC-2023-145.yaml
@@ -3,13 +3,13 @@ details: An issue in LangChain v.0.0.231 allows a remote attacker to execute arb
   code via the prompt parameter.
 aliases:
 - CVE-2023-38860
-modified: '2023-08-29T15:11:36.768403Z'
+modified: '2023-08-29T18:47:00.000000Z'
 published: '2023-08-15T17:15:00Z'
 references:
 - type: EVIDENCE
-  url: https://github.com/hwchase17/langchain/issues/7641
+  url: https://github.com/langchain-ai/langchain/issues/7641
 - type: REPORT
-  url: https://github.com/hwchase17/langchain/issues/7641
+  url: https://github.com/langchain-ai/langchain/issues/7641
 affected:
 - package:
     name: langchain
@@ -19,6 +19,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: '0.0.247'
   versions:
   - 0.0.1
   - 0.0.10
@@ -188,33 +189,9 @@ affected:
   - 0.0.244
   - 0.0.245
   - 0.0.246
-  - 0.0.247
-  - 0.0.248
-  - 0.0.249
   - 0.0.25
-  - 0.0.250
-  - 0.0.251
-  - 0.0.252
-  - 0.0.253
-  - 0.0.254
-  - 0.0.255
-  - 0.0.256
-  - 0.0.257
-  - 0.0.258
-  - 0.0.259
   - 0.0.26
-  - 0.0.260
-  - 0.0.261
-  - 0.0.262
-  - 0.0.263
-  - 0.0.264
-  - 0.0.265
-  - 0.0.266
-  - 0.0.267
-  - 0.0.268
-  - 0.0.269
   - 0.0.27
-  - 0.0.270
   - 0.0.28
   - 0.0.29
   - 0.0.3
@@ -294,12 +271,6 @@ affected:
   - 0.0.98
   - 0.0.99
   - 0.0.99rc0
-  - 0.0.271
-  - 0.0.272
-  - 0.0.273
-  - 0.0.274
-  - 0.0.275
-  - 0.0.276
 severity:
 - type: CVSS_V3
   score: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H


### PR DESCRIPTION
The affected code was removed as of `langchain v0.0.247`. Full details available in this comment from the same issue referenced in the advisory: https://github.com/langchain-ai/langchain/issues/7641#issuecomment-1697955796