### PR TITLE
Update PYSEC-2023-174 and PYSEC-2023-175 to reference CVE-2023-5129

### DIFF
--- a/vulns/imagecodecs/PYSEC-2023-174.yaml
+++ b/vulns/imagecodecs/PYSEC-2023-174.yaml
@@ -2,8 +2,9 @@ id: PYSEC-2023-174
 modified: 2023-09-20T05:12:42.403706Z
 related:
 - CVE-2023-4863
+- CVE-2023-5129
 details: imagecodecs versions before v2023.9.18 bundled libwebp binaries in wheels
-  that are vulnerable to CVE-2023-4863. imagecodecs v2023.9.18 upgrades the bundled
+  that are vulnerable to CVE-2023-5129 (previously CVE-2023-4863). imagecodecs v2023.9.18 upgrades the bundled
   libwebp binary to v1.3.2.
 affected:
 - package:
@@ -65,5 +66,7 @@ affected:
 references:
 - type: ADVISORY
   url: https://github.com/cgohlke/imagecodecs/blob/v2023.9.18/CHANGES.rst
+- type: ADVISORY
+  url: https://nvd.nist.gov/vuln/detail/CVE-2023-5129
 - type: ADVISORY
   url: https://nvd.nist.gov/vuln/detail/CVE-2023-4863

--- a/vulns/pillow/PYSEC-2023-175.yaml
+++ b/vulns/pillow/PYSEC-2023-175.yaml
@@ -1,13 +1,16 @@
 id: PYSEC-2023-175
 details: Pillow versions before v10.0.1 bundled libwebp binaries in wheels that are
-  vulnerable to CVE-2023-4863. Pillow v10.0.1 upgrades the bundled libwebp binary
+  vulnerable to CVE-2023-5129 (previously CVE-2023-4863). Pillow v10.0.1 upgrades the bundled libwebp binary
   to v1.3.2.
 modified: '2023-09-25T17:25:13.946374Z'
 related:
 - CVE-2023-4863
+- CVE-2023-5129
 references:
 - type: ADVISORY
   url: https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst#1001-2023-09-15
+- type: ADVISORY
+  url: https://nvd.nist.gov/vuln/detail/CVE-2023-5129
 - type: ADVISORY
   url: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
 affected:


### PR DESCRIPTION
Google split CVE-2023-4863 off into it's own CVE for the libwebp vulnerability specifically. I've kept references to both since the original CVE is likely to have much higher reference count at this point.