### PR TITLE
Update PYSEC-2023-162 with fix information

### DIFF
--- a/vulns/langchain/PYSEC-2023-162.yaml
+++ b/vulns/langchain/PYSEC-2023-162.yaml
@@ -3,7 +3,7 @@ details: An issue in LanChain-ai Langchain v.0.0.245 allows a remote attacker to
   arbitrary code via the evaluate function in the numexpr library.
 aliases:
 - CVE-2023-39631
-modified: '2023-10-04T16:14:57.465474Z'
+modified: '2023-10-04T16:56:57.465474Z'
 published: '2023-09-01T16:15:00Z'
 references:
 - type: EVIDENCE
@@ -17,7 +17,7 @@ references:
 - type: REPORT
   url: https://github.com/langchain-ai/langchain/issues/8363
 - type: FIX
-  url: https://github.com/langchain-ai/langchain/issues/8363
+  url: https://github.com/langchain-ai/langchain/pull/11302
 affected:
 - package:
     name: langchain
@@ -27,6 +27,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: 0.0.308
   versions:
   - 0.0.1
   - 0.0.10
@@ -337,7 +338,6 @@ affected:
   - 0.0.305
   - 0.0.306
   - 0.0.307
-  - 0.0.308
 severity:
 - type: CVSS_V3
   score: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H


### PR DESCRIPTION
Patched in LangChain v0.0.308. numexpr is optional dependency.
