### PR TITLE
suds PYSEC-2013-32 version range

### DIFF
--- a/vulns/suds/PYSEC-2013-32.yaml
+++ b/vulns/suds/PYSEC-2013-32.yaml
@@ -27,6 +27,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: '0.7.0'
   versions:
   - 0.3.4
   - 0.3.5
@@ -35,6 +36,3 @@ affected:
   - 0.3.8
   - 0.3.9
   - '0.4'
-  - 1.0.0
-  - 1.1.1
-  - 1.1.2


### PR DESCRIPTION
CVE-2013-2217 was fixed in suds 0.7.0: https://github.com/suds-community/suds/blob/master/CHANGELOG.md#version-070-2018-09-29

I see that the GHSA marks it as fixed in 1.0.0, which is also correct enough (0.7 is not on pypi).