### PR TITLE
Update affected/fixed versions for CVE-2023-46137

### DIFF
--- a/vulns/twisted/PYSEC-2023-224.yaml
+++ b/vulns/twisted/PYSEC-2023-224.yaml
@@ -19,7 +19,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - fixed: 22.10.0rc1
+    - fixed: 23.10.0rc1
   versions:
   - 1.0.1
   - 1.0.3
@@ -107,6 +107,11 @@ affected:
   - 22.4.0rc1
   - 22.8.0
   - 22.8.0rc1
+  - 22.8.0
+  - 22.10.0rc1
+  - 22.10.0
+  - 23.8.0rc1
+  - 23.8.0
   - 8.0.0
   - 8.0.1
   - 8.1.0


### PR DESCRIPTION
I believe that there's a typo in the [fixed version](https://github.com/pypa/advisory-database/blob/main/vulns/twisted/PYSEC-2023-224.yaml#L22) (therefore leading to inaccuracies in the affected versions) > `22.10.0rc1` should be `23.10.0rc1` instead based on the maintainer's advisory.

<img width="901" alt="Screenshot 2023-11-03 at 11 52 00 AM" src="https://github.com/pypa/advisory-database/assets/63199643/61a279d5-0216-4c23-a7e1-517c056e25b5">
