### PR TITLE
aiohttp: withdraw PYSEC-2022-43059

### DIFF
--- a/vulns/aiohttp/PYSEC-2022-43059.yaml
+++ b/vulns/aiohttp/PYSEC-2022-43059.yaml
@@ -1,6 +1,7 @@
 id: PYSEC-2022-43059
 modified: 2023-11-07T20:24:23.321955Z
 published: 2022-06-23T17:15:00Z
+withdrawn: 2023-11-08T00:54:24Z
 aliases:
 - CVE-2022-33124
 details: 'AIOHTTP 3.8.1 can report a "ValueError: Invalid IPv6 URL" outcome, which


### PR DESCRIPTION
I think I did this right 🙂 

Closes https://github.com/pypa/advisory-database/issues/83.

See https://github.com/aio-libs/aiohttp/issues/6801, https://github.com/aio-libs/aiohttp/issues/6772