### PR TITLE
PYSEC-2023-221 also fixed in 2.3.8

### DIFF
--- a/vulns/werkzeug/PYSEC-2023-221.yaml
+++ b/vulns/werkzeug/PYSEC-2023-221.yaml
@@ -29,8 +29,17 @@ affected:
     - fixed: f3c803b3ade485a45f12b6d6617595350c0f03e2
   - type: ECOSYSTEM
     events:
-    - introduced: '0'
+    - introduced: 3.0.0
     - fixed: 3.0.1
+  - type: GIT
+    repo: https://github.com/pallets/werkzeug
+    events:
+    - introduced: '0'
+    - fixed: f2300208d5e2a5076cbbb4c2aad71096fd040ef9
+  - type: ECOSYSTEM
+    events:
+    - introduced: '0'
+    - fixed: 2.3.8
   versions:
   - '0.1'
   - '0.10'
@@ -122,7 +131,6 @@ affected:
   - 2.3.6
   - 2.3.7
   - 3.0.0
-  - 2.3.8
 severity:
 - type: CVSS_V3
   score: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H

--- a/vulns/werkzeug/PYSEC-2023-221.yaml
+++ b/vulns/werkzeug/PYSEC-2023-221.yaml
@@ -27,19 +27,13 @@ affected:
     events:
     - introduced: '0'
     - fixed: f3c803b3ade485a45f12b6d6617595350c0f03e2
-  - type: ECOSYSTEM
-    events:
-    - introduced: 3.0.0
-    - fixed: 3.0.1
-  - type: GIT
-    repo: https://github.com/pallets/werkzeug
-    events:
-    - introduced: '0'
     - fixed: f2300208d5e2a5076cbbb4c2aad71096fd040ef9
   - type: ECOSYSTEM
     events:
     - introduced: '0'
     - fixed: 2.3.8
+    - introduced: 3.0.0
+    - fixed: 3.0.1
   versions:
   - '0.1'
   - '0.10'


### PR DESCRIPTION
PYSEC-2023-221 was also fixed in legacy version 2.3.8 https://github.com/pallets/werkzeug/security/advisories/GHSA-hrfv-mqp8-q5rw

closes #171 