### PR TITLE
Add affected attribute format

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For example, a vulnerability that affects PIL::ImageFont can be represented as..
   }
 ]
 ```
-which is equivalent to `PIL:ImageFont`. If a second attribute `ImageFont2` is also affected then a second payload should be added and delimited with a `;`. Eg.
+which is equivalent to `PIL:ImageFont`. If a second attribute `ImageFont2` is also affected, then a second import entry needs to be added to the `imports` array. 
 ```json
 "imports": [
   { "attribute": "ImageFont", "modules": ["PIL"] },

--- a/README.md
+++ b/README.md
@@ -27,21 +27,34 @@ generate the `.yaml` entries here.
 ## Using this data
 
 ### Marking specific attributes
-It can be helpful to know which specific code elements of a package are vulnerable and this is done by appending an attribute and list of module paths starting from the top level module of a package to the OSV payload. Eg.  
+It can be helpful to know which specific code elements of a package are vulnerable and this is done by appending an attribute and list of module paths starting from the top level module of a package to the OSV payload. Eg. 
+OSV entries in this database have the following ecosystem_specific definition: 
 ```json
-{
-  "attribute": "ImageFont",
-  "modules": ["PIL"]
+"ecosystem_specific": {
+  "imports": [
+    { 
+       "attribute": string,
+       "modules": [ string ],
+    }
+  ]
 }
+```
+"imports" is a JSON array containing the modules and attributes affected by the vulnerability...
+For example, a vulnerability that affects PIL::ImageFont can be represented as...
+```json
+"imports": [
+  {
+    "attribute": "ImageFont",
+    "modules": ["PIL"]
+  }
+]
 ```
 which is equivalent to `PIL:ImageFont`. If a second attribute `ImageFont2` is also affected then a second payload should be added and delimited with a `;`. Eg.
-```
-{
-  attribute: "ImageFont",
-  modules: ["PIL"];
-  attribute: "ImageFont2",
-  modules: ["PIL"]
-}
+```json
+"imports": [
+  { "attribute": "ImageFont", "modules": ["PIL"] },
+  { "attribute": "ImageFont2", "modules": ["PIL"] }
+]
 ```
 
 attributes which are accessible via multiple paths may be represented in a condensed form. Consider the attribute `django.db.models:JSONField` from the [django project](https://github.com/django/django/blob/0ee2b8c326d47387bacb713a3ab369fa9a7a22ee/django/db/models/__init__.py#L99) 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ which is equivalent to `PIL:ImageFont`. If a second attribute `ImageFont2` is al
 ]
 ```
 
-attributes which are accessible via multiple paths may be represented in a condensed form. Consider the attribute `django.db.models:JSONField` from the [django project](https://github.com/django/django/blob/0ee2b8c326d47387bacb713a3ab369fa9a7a22ee/django/db/models/__init__.py#L99) 
+Attributes which are accessible via multiple paths may be represented in a condensed form. Consider the attribute `django.db.models:JSONField` from the [django project](https://github.com/django/django/blob/0ee2b8c326d47387bacb713a3ab369fa9a7a22ee/django/db/models/__init__.py#L99) 
 The attribute `django.db.models:JSONField` is a re-export of `django.db.models.fields.json:JSONField` and both are valid paths.
 These can be condensed to a more compact OSV representation as 
 ```

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ generate the `.yaml` entries here.
 It can be helpful to know which specific code elements of a package are vulnerable and this is done by appending an attribute and list of module paths to that attribute to the OSV payload. Eg. 
 ```json
 {
-  attribute: "ImageFont",
-  modules: ["PIL"]
+  "attribute": "ImageFont",
+  "modules": ["PIL"]
 }
 ```
 which is equivalent to `PIL:ImageFont`. If a second attribute `ImageFont2` is also affected then a second payload should be added and delimited with a `;`. Eg.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ generate the `.yaml` entries here.
 ## Using this data
 
 ### Marking specific attributes
-It can be helpful to know which specific code elements of a package are vulnerable and this is done by appending an attribute and list of module paths to that attribute to the OSV payload. Eg. 
+It can be helpful to know which specific code elements of a package are vulnerable and this is done by appending an attribute and list of module paths starting from the top level module of a package to the OSV payload. Eg.  
 ```json
 {
   "attribute": "ImageFont",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ generate the `.yaml` entries here.
 
 ### Marking specific attributes
 It can be helpful to know which specific code elements of a package are vulnerable and this is done by appending an attribute and list of module paths to that attribute to the OSV payload. Eg. 
-```
+```json
 {
   attribute: "ImageFont",
   modules: ["PIL"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,34 @@ generate the `.yaml` entries here.
 
 ## Using this data
 
+### Marking specific attributes
+It can be helpful to know which specific code elements of a package are vulnerable and this is done by appending an attribute and list of module paths to that attribute to the OSV payload. Eg. 
+```
+{
+  attribute: "ImageFont",
+  modules: ["PIL"]
+}
+```
+which is equivalent to `PIL:ImageFont`. If a second attribute `ImageFont2` is also affected then a second payload should be added and delimited with a `;`. Eg.
+```
+{
+  attribute: "ImageFont",
+  modules: ["PIL"];
+  attribute: "ImageFont2",
+  modules: ["PIL"]
+}
+```
+
+attributes which are accessible via multiple paths may be represented in a condensed form. Consider the attribute `django.db.models:JSONField` from the [django project](https://github.com/django/django/blob/0ee2b8c326d47387bacb713a3ab369fa9a7a22ee/django/db/models/__init__.py#L99) 
+The attribute `django.db.models:JSONField` is a re-export of `django.db.models.fields.json:JSONField` and both are valid paths.
+These can be condensed to a more compact OSV representation as 
+```
+{
+  attribute: "JSONField",
+  modules: ["django.db.models", "django.db.models.fields.json"]
+}
+```
+
 ### Tooling
 
 This data is exposed by [`pip-audit`](https://github.com/pypa/pip-audit),


### PR DESCRIPTION
Following up on #149 it seems like we have general agreement on what this format should be, so I've gone ahead and kicked off the PR 🎉 I took a liberty in how to deliniate two attributes (with a `;`). Happy to change that if there's disagreement on how to delimit multiple different attributes on the same osv payload. The osv payload is explicitly called out as equivalent to the dot-colon single line format as well.

~I also added a brief section linking to the osv schema.~ I did in a prior version of the commit then removed it after noticing there was already a link to the osv schema 🤦 

Happy to move the target of this change or to change the wording or whatever :) 