### PR TITLE
chore: update actions/checkout

### DIFF
--- a/.github/workflows/auto_import.yaml
+++ b/.github/workflows/auto_import.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Auto import
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.16.4'

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Analysis
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 64
     - uses: google/osv/actions/analyze@master
@@ -32,7 +32,7 @@ jobs:
     name: Assign IDs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.16.4'


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-go@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/