### PR TITLE
fix affected version on recent pypi exiv2 records

### DIFF
--- a/vulns/exiv2/PYSEC-2024-106.yaml
+++ b/vulns/exiv2/PYSEC-2024-106.yaml
@@ -1,5 +1,5 @@
 id: PYSEC-2024-106
-modified: 2024-10-16T21:22:52.163301Z
+modified: 2024-10-23T00:00:00Z
 published: 2024-02-12T23:15:00Z
 aliases:
 - CVE-2024-24826

--- a/vulns/exiv2/PYSEC-2024-106.yaml
+++ b/vulns/exiv2/PYSEC-2024-106.yaml
@@ -20,32 +20,10 @@ affected:
   ranges:
   - type: ECOSYSTEM
     events:
-    - introduced: "0"
+    - introduced: "0.16.0"
+    - fixed: "0.16.1"
   versions:
-  - "0.1"
-  - 0.11.0
-  - 0.11.1
-  - 0.11.2
-  - 0.11.3
-  - 0.12.0
-  - 0.12.1
-  - 0.13.0
-  - 0.13.1
-  - 0.13.2
-  - 0.14.0
-  - 0.14.1
-  - 0.15.0
   - 0.16.0
-  - 0.16.1
-  - 0.16.2
-  - 0.16.2.post1
-  - 0.16.3
-  - 0.16.3.post1
-  - 0.17.0
-  - 0.17.1
-  - "0.2"
-  - "0.3"
-  - 0.3.1
 severity:
 - type: CVSS_V3
   score: CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:H

--- a/vulns/exiv2/PYSEC-2024-107.yaml
+++ b/vulns/exiv2/PYSEC-2024-107.yaml
@@ -1,5 +1,5 @@
 id: PYSEC-2024-107
-modified: 2024-10-16T21:22:52.208852Z
+modified: 2024-10-23T00:00:00Z
 published: 2024-02-12T23:15:00Z
 aliases:
 - CVE-2024-25112

--- a/vulns/exiv2/PYSEC-2024-107.yaml
+++ b/vulns/exiv2/PYSEC-2024-107.yaml
@@ -20,32 +20,10 @@ affected:
   ranges:
   - type: ECOSYSTEM
     events:
-    - introduced: "0"
+    - introduced: "0.16.0"
+    - fixed: "0.16.1"
   versions:
-  - "0.1"
-  - 0.11.0
-  - 0.11.1
-  - 0.11.2
-  - 0.11.3
-  - 0.12.0
-  - 0.12.1
-  - 0.13.0
-  - 0.13.1
-  - 0.13.2
-  - 0.14.0
-  - 0.14.1
-  - 0.15.0
   - 0.16.0
-  - 0.16.1
-  - 0.16.2
-  - 0.16.2.post1
-  - 0.16.3
-  - 0.16.3.post1
-  - 0.17.0
-  - 0.17.1
-  - "0.2"
-  - "0.3"
-  - 0.3.1
 severity:
 - type: CVSS_V3
   score: CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:H


### PR DESCRIPTION
Per the following upstream advisories for libexiv2:
- https://github.com/Exiv2/exiv2/security/advisories/GHSA-g9xm-7538-mq8w
- https://github.com/Exiv2/exiv2/security/advisories/GHSA-crmj-qh74-2r36

only versions 0.28.0 and 0.28.1 of libexiv2 are affected, and after inspection of the wheels available for the [exiv2 on PyPI](https://pypi.org/project/exiv2/), I believe only v0.16.0 includes an affected version of libexiv2:

| pypi exiv2 version| bundled libexiv2 version | affected |
| ----------------- | ----------------------- | ------- |
| 0.16.0 | 0.28.1 |true |
| 0.16.1 |0.27.7 | false |
| 0.16.2 | 0.27.7 | false |
| 0.16.2.post1 | 0.27.7 | false |
| 0.16.3 | 0.28.2 | false |