### PR TITLE
PYSEC-2024-115: Update affected packages & versions

### DIFF
--- a/vulns/langchain/PYSEC-2024-115.yaml
+++ b/vulns/langchain/PYSEC-2024-115.yaml
@@ -1,5 +1,5 @@
 id: PYSEC-2024-115
-details: A vulnerability in the GraphCypherQAChain class of langchain-ai/langchain
+details: A vulnerability in the GraphCypherQAChain class of langchain-ai/langchain-community
   version 0.2.5 allows for SQL injection through prompt injection. This vulnerability
   can lead to unauthorized data manipulation, data exfiltration, denial of service
   (DoS) by deleting all data, breaches in multi-tenant security environments, and
@@ -9,7 +9,7 @@ details: A vulnerability in the GraphCypherQAChain class of langchain-ai/langcha
 aliases:
 - CVE-2024-8309
 modified: '2024-11-04T19:21:45.015489Z'
-published: '2024-10-29T13:15:00Z'
+published: '2024-11-05T16:04:14Z'
 references:
 - type: EVIDENCE
   url: https://huntr.com/bounties/8f4ad910-7fdc-4089-8f0a-b5df5f32e7c5
@@ -31,6 +31,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: '0'
+    - fixed: '0.2.0'
   versions:
   - 0.0.1
   - 0.0.10
@@ -418,36 +419,34 @@ affected:
   - 0.1.7
   - 0.1.8
   - 0.1.9
+- package:
+    name: langchain-community
+    ecosystem: PyPI
+    purl: pkg:pypi/langchain-community
+  ranges:
+  - type: ECOSYSTEM
+    events:
+    - introduced: '0.2.0'
+    - fixed: '0.3.0'
+  versions:
   - 0.2.0
-  - 0.2.0rc1
-  - 0.2.0rc2
   - 0.2.1
-  - 0.2.10
-  - 0.2.11
-  - 0.2.12
-  - 0.2.13
-  - 0.2.14
-  - 0.2.15
-  - 0.2.16
   - 0.2.2
   - 0.2.3
   - 0.2.4
   - 0.2.5
   - 0.2.6
   - 0.2.7
-  - 0.2.8
   - 0.2.9
-  - 0.3.0
-  - 0.3.0.dev1
-  - 0.3.0.dev2
-  - 0.3.1
-  - 0.3.2
-  - 0.3.3
-  - 0.3.4
-  - 0.3.5
-  - 0.3.6
-  - 0.3.7
+  - 0.2.10
+  - 0.2.11
+  - 0.2.12
+  - 0.2.13
+  - 0.2.15
+  - 0.2.16
   - 0.2.17
+  - 0.2.18
+
 severity:
 - type: CVSS_V3
   score: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H


### PR DESCRIPTION
This affects langchain-community 0.2.0-0.3.0 and langchain <0.2.0

Closes https://github.com/pypa/advisory-database/issues/200

Apologies if the fix is misformatted; ran 
```
pipx run check-jsonschema --schemafile https://raw.githubusercontent.com/ossf/osv-schema/main/validation/schema.json vul
ns/langchain/PYSEC-2024-115.yaml
```

but i'm sure there's other checks you do manually