### PR TITLE
Withdraw PYSEC-2024-27.yaml

### DIFF
--- a/vulns/crate/PYSEC-2024-27.yaml
+++ b/vulns/crate/PYSEC-2024-27.yaml
@@ -1,6 +1,7 @@
 id: PYSEC-2024-27
 modified: 2024-02-06T20:20:19.010821Z
 published: 2024-01-30T01:15:00Z
+withdrawn: 2024-11-20T09:19.00Z
 aliases:
 - CVE-2023-51982
 details: CrateDB 5.5.1 is contains an authentication bypass vulnerability in the Admin


### PR DESCRIPTION
The Python crate library uses CrateDB exclusively for automated tests in a GitHub Action. The reported vulnerability affects only CrateDB, not the library itself.

https://github.com/advisories/GHSA-7mgx-gvjw-m3w3

also see: https://github.com/crate/crate-python/commit/813946b9420d45877ef7c369311dbc8804d6674f