### PR TITLE
withdraw PYSEC-2019-125

### DIFF
--- a/triage/false_positives.yaml
+++ b/triage/false_positives.yaml
@@ -69,3 +69,4 @@ packages:
 - wolfssl  # Most likely not the python package.
 - krb5    # Most likely not the python package.
 - hyperledger # Most likely not the python package.
+- steam # The python steam package is unlikely to be the target package of a vulnerability

--- a/vulns/steam/PYSEC-2019-125.yaml
+++ b/vulns/steam/PYSEC-2019-125.yaml
@@ -28,3 +28,4 @@ aliases:
 - CVE-2019-17180
 modified: "2020-01-16T13:15:00Z"
 published: "2019-10-04T20:15:00Z"
+withdrawn: "2026-06-09T14:56:00Z"


### PR DESCRIPTION
This is not for the `steam` python package on pypi, but for the actual steam client.

Resolves #233