### PR TITLE
fix modified timestamp for PYSEC-2024-55

### DIFF
--- a/vulns/cipherbcrypt/PYSEC-2024-55.yaml
+++ b/vulns/cipherbcrypt/PYSEC-2024-55.yaml
@@ -1,5 +1,6 @@
 id: PYSEC-2024-55
-modified: 0001-01-01T00:00:00Z
+published: 2024-07-09T09:56:00Z
+modified: 2026-06-09T16:05:00Z
 details: Malicious package. Exfiltrated secrets to a target server.
 affected:
 - package:


### PR DESCRIPTION
Also adds backdated published timestamp.  This advisory was added in https://github.com/pypa/advisory-database/pull/184

Resolves #247