### PR TITLE
Correct PYSEC-2026-1723: add fixed version 0.5.13

### DIFF
--- a/vulns/open-webui/PYSEC-2026-1723.yaml
+++ b/vulns/open-webui/PYSEC-2026-1723.yaml
@@ -1,6 +1,6 @@
 id: PYSEC-2026-1723
 published: "2026-07-07T14:34:56.331499Z"
-modified: "2026-07-07T17:24:53.957822Z"
+modified: "2026-07-22T20:32:29Z"
 aliases:
 - CVE-2024-7983
 - GHSA-5v9m-57mq-qc75
@@ -15,7 +15,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - last_affected: 0.3.8
+    - fixed: 0.5.13
   versions:
   - 0.1.124
   - 0.1.125


### PR DESCRIPTION
I am a maintainer of the affected project (`open-webui/open-webui`). This advisory carries no fixed version and an understated affected range, so it produces perpetual unfixable false positives in Dependabot and downstream scanners even though the issue was remediated.

For the record, as maintainer: the unauthenticated `POST /api/v1/utils/markdown` conversion endpoint was gated with `get_verified_user` in commit 2f75eef49 ("enh: code execution settings"), first released in v0.5.13.

This change corrects the OSV `affected` range to `fixed: 0.5.13`, which records the patched version and fixes the understated upper bound in one edit.