### PR TITLE
Correct PYSEC-2026-1736: add fixed version 0.3.33

### DIFF
--- a/vulns/open-webui/PYSEC-2026-1736.yaml
+++ b/vulns/open-webui/PYSEC-2026-1736.yaml
@@ -1,6 +1,6 @@
 id: PYSEC-2026-1736
 published: "2026-07-07T14:34:54.273440Z"
-modified: "2026-07-07T17:24:54.800732Z"
+modified: "2026-07-22T20:32:29Z"
 aliases:
 - CVE-2024-7044
 - GHSA-j274-m559-cj4j
@@ -15,7 +15,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - last_affected: 0.3.8
+    - fixed: 0.3.33
   versions:
   - 0.1.124
   - 0.1.125


### PR DESCRIPTION
I am a maintainer of the affected project (`open-webui/open-webui`). This advisory carries no fixed version and an understated affected range, so it produces perpetual unfixable false positives in Dependabot and downstream scanners even though the issue was remediated.

For the record, as maintainer: uploaded files were served inline without `Content-Disposition`; the fix forcing `Content-Disposition: attachment` (commit 0da0e1209, "refac: file download") first shipped in v0.3.33.

This change corrects the OSV `affected` range to `fixed: 0.3.33`, which records the patched version and fixes the understated upper bound in one edit.