### PR TITLE
Correct PYSEC-2026-1732: add fixed version 0.9.0

### DIFF
--- a/vulns/open-webui/PYSEC-2026-1732.yaml
+++ b/vulns/open-webui/PYSEC-2026-1732.yaml
@@ -1,6 +1,6 @@
 id: PYSEC-2026-1732
 published: "2026-07-07T16:03:12.102402Z"
-modified: "2026-07-07T17:24:54.562708Z"
+modified: "2026-07-22T20:32:29Z"
 aliases:
 - CVE-2025-63681
 - GHSA-frv8-gffc-37px
@@ -15,7 +15,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - last_affected: 0.6.33
+    - fixed: 0.9.0
   versions:
   - 0.1.124
   - 0.1.125


### PR DESCRIPTION
I am a maintainer of the affected project (`open-webui/open-webui`). This advisory carries no fixed version and an understated affected range, so it produces perpetual unfixable false positives in Dependabot and downstream scanners even though the issue was remediated.

For the record, as maintainer: the global task endpoints lacked an ownership check; ownership checks and admin-gating were added in commit e7ff4768f (PR #23454), first released in v0.9.0.

This change corrects the OSV `affected` range to `fixed: 0.9.0`, which records the patched version and fixes the understated upper bound in one edit.