### PR TITLE
Correct PYSEC-2026-1739: add fixed version 0.3.16

### DIFF
--- a/vulns/open-webui/PYSEC-2026-1739.yaml
+++ b/vulns/open-webui/PYSEC-2026-1739.yaml
@@ -1,6 +1,6 @@
 id: PYSEC-2026-1739
 published: "2026-07-07T14:34:55.510870Z"
-modified: "2026-07-07T17:24:54.981091Z"
+modified: "2026-07-22T20:32:29Z"
 aliases:
 - CVE-2024-7035
 - GHSA-p5vx-9hj8-cf4h
@@ -15,7 +15,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - last_affected: 0.3.8
+    - fixed: 0.3.16
   versions:
   - 0.1.124
   - 0.1.125


### PR DESCRIPTION
I am a maintainer of the affected project (`open-webui/open-webui`). This advisory carries no fixed version and an understated affected range, so it produces perpetual unfixable false positives in Dependabot and downstream scanners even though the issue was remediated.

For the record, as maintainer: the state-changing reset endpoints were served via GET (CSRF-able via top-level navigation given the token-cookie auth fallback); they were changed from GET to POST in v0.3.16, closing the CSRF vector.

This change corrects the OSV `affected` range to `fixed: 0.3.16`, which records the patched version and fixes the understated upper bound in one edit.