### PR TITLE
Correct affected range/fixed version for PYSEC-2026-1744 (CVE-2024-7041)

### DIFF
--- a/vulns/open-webui/PYSEC-2026-1744.yaml
+++ b/vulns/open-webui/PYSEC-2026-1744.yaml
@@ -1,6 +1,6 @@
 id: PYSEC-2026-1744
 published: "2026-07-07T14:34:42.852864Z"
-modified: "2026-07-07T17:24:55.295923Z"
+modified: "2026-07-22T21:05:51Z"
 aliases:
 - CVE-2024-7041
 - GHSA-xcvc-5hgv-phqg
@@ -15,25 +15,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - last_affected: 0.3.8
-  versions:
-  - 0.1.124
-  - 0.1.125
-  - 0.2.0
-  - 0.2.1
-  - 0.2.2
-  - 0.2.3
-  - 0.2.4
-  - 0.2.5
-  - 0.3.0
-  - 0.3.1
-  - 0.3.2
-  - 0.3.3
-  - 0.3.4
-  - 0.3.5
-  - 0.3.6
-  - 0.3.7
-  - 0.3.8
+    - fixed: 0.6.3
 references:
 - type: ADVISORY
   url: https://nvd.nist.gov/vuln/detail/CVE-2024-7041


### PR DESCRIPTION
Corrects the affected range for PYSEC-2026-1744 / CVE-2024-7041.

The record currently ends the range at `last_affected: 0.3.8`, which understates the affected versions; the issue was fixed in a later release. This PR replaces it with `fixed: 0.6.3` (the first fixed release) and removes the now-inconsistent enumerated `versions` list so it can be regenerated from the corrected range. See the paired GitHub advisory correction for the fix-commit evidence.
