### PR TITLE
Correct affected range/fixed version for PYSEC-2026-1722 (CVE-2024-6706)

### DIFF
--- a/vulns/open-webui/PYSEC-2026-1722.yaml
+++ b/vulns/open-webui/PYSEC-2026-1722.yaml
@@ -1,6 +1,6 @@
 id: PYSEC-2026-1722
 published: "2026-07-07T14:34:38.600149Z"
-modified: "2026-07-07T14:34:38.600149Z"
+modified: "2026-07-22T21:05:51Z"
 aliases:
 - CVE-2024-6706
 - GHSA-5jp3-wp5v-5363
@@ -15,7 +15,7 @@ affected:
   - type: ECOSYSTEM
     events:
     - introduced: "0"
-    - last_affected: 0.1.105
+    - fixed: 0.3.14
 references:
 - type: ADVISORY
   url: https://nvd.nist.gov/vuln/detail/CVE-2024-6706


### PR DESCRIPTION
Corrects the affected range for PYSEC-2026-1722 / CVE-2024-6706.

The record currently ends the range at `last_affected: 0.1.105`, which understates the affected versions; the issue was fixed in a later release. This PR replaces it with `fixed: 0.3.14` (the first fixed release) and removes the now-inconsistent enumerated `versions` list so it can be regenerated from the corrected range. See the paired GitHub advisory correction for the fix-commit evidence.
